### PR TITLE
Removed compromised website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,6 @@ The LSP is all about expected behavior of objects:
 Resources
 
 * [Liskov substitution principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle)
-* [The Liskov Substitution Principle](http://freshbrewedcode.com/derekgreer/2011/12/31/solid-javascript-the-liskov-substitution-principle/)
 
 ## Open/Closed Principle
 
@@ -316,7 +315,6 @@ How
 Resources
 
 * [Open Closed Principle](http://en.wikipedia.org/wiki/Open/closed_principle)
-* [SOLID JavaScript: The Open/Closed Principle](http://freshbrewedcode.com/derekgreer/2011/12/19/solid-javascript-the-openclosed-principle/)
 
 ## Single Responsibility Principle
 
@@ -383,7 +381,7 @@ Resources
 
 ## Interface Segregation Principle
 
-Reduce fat interfaces into multiple smaller and more specific client specific interfaces. An interface should be more dependent on the code that calls it than the code that implements it. 
+Reduce fat interfaces into multiple smaller and more specific client specific interfaces. An interface should be more dependent on the code that calls it than the code that implements it.
 
 Why
 

--- a/index.md
+++ b/index.md
@@ -305,7 +305,6 @@ The LSP is all about expected behavior of objects:
 Resources
 
 * [Liskov substitution principle](http://en.wikipedia.org/wiki/Liskov_substitution_principle)
-* [The Liskov Substitution Principle](http://freshbrewedcode.com/derekgreer/2011/12/31/solid-javascript-the-liskov-substitution-principle/)
 
 ## Open/Closed Principle
 
@@ -323,7 +322,6 @@ How
 Resources
 
 * [Open Closed Principle](http://en.wikipedia.org/wiki/Open/closed_principle)
-* [SOLID JavaScript: The Open/Closed Principle](http://freshbrewedcode.com/derekgreer/2011/12/19/solid-javascript-the-openclosed-principle/)
 
 ## Single Responsibility Principle
 
@@ -390,7 +388,7 @@ Resources
 
 ## Interface Segregation Principle
 
-Reduce fat interfaces into multiple smaller and more specific client specific interfaces. An interface should be more dependent on the code that calls it than the code that implements it. 
+Reduce fat interfaces into multiple smaller and more specific client specific interfaces. An interface should be more dependent on the code that calls it than the code that implements it.
 
 Why
 


### PR DESCRIPTION
README.md and index.md had two links pointing to compromised websites.

Per request on https://github.com/iluwatar/java-design-patterns/issues/577 I have fixed the links here on the repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webpro/programming-principles/24)
<!-- Reviewable:end -->
