### PR TITLE
fix: anchor link for curly's law from Single Responsibility Principle section

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Why
 
 How
 
-- Apply [Curly's Law](#Curlys-Law).
+- Apply [Curly's Law](#curlys-Law).
 
 Resources
 

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Why
 
 How
 
-- Apply [Curly's Law](#Curly-s-Law).
+- Apply [Curly's Law](#Curlys-Law).
 
 Resources
 


### PR DESCRIPTION
Updating the hyperlink for Curly's Law from the Single Responsibility Principle section, with GitHub's Markdown rules (from https://stackoverflow.com/questions/27981247/github-markdown-same-page-link)